### PR TITLE
Improve /events/followers.js

### DIFF
--- a/beastie-client.js
+++ b/beastie-client.js
@@ -14,7 +14,7 @@ const secrets = require("./config/secrets");
 var beastie = new tmi.client(
     _.defaults({
         identity: secrets.TTsBeastie,
-        channels: ["#teamTALIMA"]
+        channels: [secrets.broadcaster.username]
     },  require ("./config/config"))
 );
 

--- a/beastie-functions.js
+++ b/beastie-functions.js
@@ -1,6 +1,6 @@
 // TTsBeastie custom functions
 
-
+const secrets = require("./config/secrets");
 
 /**
  * CUSTOM TTsBEASTIE FUNCTIONS
@@ -24,10 +24,12 @@ module.exports.getArrayElement =    function(array){
                                     }
 
 module.exports.queryTwitchAPI =     function(queryUrl){
-                                        url: "https://api.twitch.tv/kraken/" + queryUrl,
-                                        headers: {
-                                            "Accept": "application/vnd.twitchtv.v5+json",
-                                            "Authorization": "OAuth " + secrets.broadcaster.password,
-                                            "Client-ID": secrets.clientId
-                                        }
+                                        return {
+                                            url: "https://api.twitch.tv/kraken/" + queryUrl,
+                                            headers: {
+                                                "Accept": "application/vnd.twitchtv.v5+json",
+                                                "Authorization": "OAuth " + secrets.broadcaster.password,
+                                                "Client-ID": secrets.clientId
+                                            }
+                                        };
                                     }

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -115,7 +115,7 @@ var commands = {
                                         var minutes = Math.floor(diff / 60) % 60;
                                         var seconds = Math.floor(diff - (hours * 60 * 60) - (minutes * 60));
 
-                                        queue.addMessage( channel, "teamTALIMA has been LIVE for: " + hours + " hours " + minutes + " minutes " + seconds + " seconds. rawr");
+                                        queue.addMessage( channel, secrets.broadcaster.username + " has been LIVE for: " + hours + " hours " + minutes + " minutes " + seconds + " seconds. rawr");
                                     }
                                 });
                             }

--- a/events/followers.js
+++ b/events/followers.js
@@ -4,6 +4,7 @@
 
 // Setup Files
 const beastie = require("../beastie-client");
+const beastieFunctions = require("../beastie-functions");
 const secrets = require("../config/secrets");
 
 // array of new followers which need to be acknowledged

--- a/events/followers.js
+++ b/events/followers.js
@@ -48,11 +48,20 @@ function checkFollows(id){
     beastie.api(beastieFunctions.queryTwitchAPI(
         "channels/" + id + "/follows/"
     ), function(err, res, body) {
+        if(err) {
+            console.error("There was a problem querying the Twitch API for follows:");
+            console.error(err);
+        }
         if(!err){
+            if (body.follows == null || "error" in body) {
+                console.warn("There was no follows array returned in the Twitch API response. :/");
+                if(body.error) console.error(body.error + ": " + body.message);
+                return;
+            }
             if (latestFollow == "#") {
                 // for BeastieBot startup
                 latestFollow = body.follows[0].user.display_name;
-            } else{
+            } else {
                 // check for new follows
                 for( let i = 0; i < body.follows.length; i++){
                     if(body.follows[i].user.display_name != latestFollow){
@@ -65,8 +74,8 @@ function checkFollows(id){
                         break;
                     }
                 }
-            // error with api call, reset variables
-            latestFollow = body.follows[0].user.display_name; // update to make sure 'lastestFollow' is in body.follows next call
+                // error with api call, reset variables
+                latestFollow = body.follows[0].user.display_name; // update to make sure 'lastestFollow' is in body.follows next call
             }
         }
     });    


### PR DESCRIPTION
 - Improves error handling when Twitch API returns no follows array.
 - Makes commands channel agnostic and fixes `/events/followers.js` to require `/beastie-functions.js`
   - Fixes #4

I can verify that Beastie completely works on my channel when I ran `npm install` (installed Beastie's dependencies) and configured the `/config/secrets.js`. 👍 