### PR TITLE
Fixed hosted events and raid system, a new setting for autohost events, and more

### DIFF
--- a/config/settings.ini
+++ b/config/settings.ini
@@ -28,6 +28,7 @@ startup="Hello Team! :D I have awoken! Welcome back to teamTALIMA's channel!"
 shutdown="Goodbye Team! I'm going to sleep."
 
 [announce.hosted]
+autohosts=true
 threshold=3
 
 [timers]

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -24,7 +24,7 @@ teamsite="http://teamtalima.com"
 teamwall="http://teamtalima.com/team-wall/"
 
 [announce]
-startup="Hello Team! :D I have awoken! Welcome back to Scryptonite's channel!"
+startup="Hello Team! :D I have awoken! Welcome back to teamTALIMA's channel!"
 shutdown="Goodbye Team! I'm going to sleep."
 
 [announce.hosted]

--- a/config/settings.ini
+++ b/config/settings.ini
@@ -1,4 +1,4 @@
-home=teamtalima
+home=
 chat_interval=500
 
 [loyalty]

--- a/src/chatbot/commands/raids.js
+++ b/src/chatbot/commands/raids.js
@@ -2,6 +2,7 @@ const settings = require("../../misc/settings");
 const secrets = require("../../misc/secrets");
 
 const qs = require("querystring");
+const chalk = require("chalk");
 const _ = require("../../misc/utils");
 const api = require("../../misc/api");
 

--- a/src/chatbot/events/hosts.js
+++ b/src/chatbot/events/hosts.js
@@ -10,6 +10,7 @@ module.exports = async (client) => {
 
     broadcaster.on("hosted", async (home, away, viewers) => {
         if(![settings.home, broadcaster.user.channel].includes(home)
+        if([settings.home, broadcaster.user.channel].includes(home)
         && viewers >= parseInt(_.get(settings, "announce.hosted.threshold", 0), 10)){
             const time = new Date();
             const friend = await api.twitch({ name: away });

--- a/src/chatbot/events/hosts.js
+++ b/src/chatbot/events/hosts.js
@@ -8,8 +8,10 @@ module.exports = async (client) => {
 
     const hosts = [];
 
-    broadcaster.on("hosted", async (home, away, viewers) => {
-        if(![settings.home, broadcaster.user.channel].includes(home)
+    broadcaster.on("hosted", async (home, away, viewers, autohost) => {
+        if(autohost && !_.get(settings, "announce.hosted.autohosts", true)) 
+            return;
+
         if([settings.home, broadcaster.user.channel].includes(home)
         && viewers >= parseInt(_.get(settings, "announce.hosted.threshold", 0), 10)){
             const time = new Date();

--- a/src/misc/api/client.js
+++ b/src/misc/api/client.js
@@ -51,7 +51,7 @@ module.exports = api => ({
         }
 
         client.on("cheer", (channel, userstate, message) => {
-            client.emit("message", _.assign(userstate, { "message-type": "cheer" }), message);
+            client.emit("message", channel, _.assign(userstate, { "message-type": "cheer" }), message);
         });
 
         client.on("hosting", (channel, target, viewers) => {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -32,7 +32,8 @@ const forever = require("forever-monitor");
     if(await _.pid.check("beastie-webserver"))
         await _.pid.kill("beastie-webserver");
     beastieWebserver = await _.startForeverProcess("./webserver", {
-        cwd: __dirname
+        cwd: __dirname,
+        sourceDir: __dirname
     }, "beastie-webserver");
     beastieWebserver.monitor.on("restart", function() {
         console.error("[beastie-monitor] restarting [beastie-webserver] for " + beastieWebserver.monitor.times + " time");
@@ -44,7 +45,8 @@ const forever = require("forever-monitor");
     if(await _.pid.check("beastie-chatbot"))
         await _.pid.kill("beastie-chatbot");
     beastieChatbot = await _.startForeverProcess("./chatbot", {
-        cwd: __dirname
+        cwd: __dirname,
+        sourceDir: __dirname
     }, "beastie-chatbot");
     beastieChatbot.monitor.on("restart", function() {
         console.error("[beastie-monitor] restarting [beastie-chatbot] for " + beastieChatbot.monitor.times + " time");


### PR DESCRIPTION
- `config/settings.ini`
    - Updated `home` to *empty*, so that it's the broadcaster's channel by default.
    - Updated `[announce]`'s `startup` to <code>"Hello Team! :D I have awoken! Welcome back to <strong>teamTALIMA</strong>'s channel!"</code>. Fixes Beastie welcoming people to my (Scryptonite's) channel by default. Oops.
- `src/chatbot/commands/raid.js`
    - :star: Added `const chalk = require("chalk");` to the top. Fixes Beastie crashing when seeing someone raid in another channel and attempting to log in color when `chalk` is undefined. Oops.
- `src/chatbot/events/hosts.js`
    - :star: Updated so `hosted` event should now fire -- accidentally made the conditional read `if hosted channel is not (home channel or broadcaster's channel)` instead of `if hosted channel is (home channel or broadcaster's channel)`. Oops.
    - Updated to optionally announce autohosts via `announce.hosted.autohosts` setting (default: true, autohosts announcements are enabled).
- `src/misc/api/client.js`
    - Updated so `cheer` events are transformed into a `message` event correctly. Now people may `!rawr cheer10`, or cheer in a raid target's chatroom and have it qualify as a raid message. Also cheer events should now be logged to the console correctly. 👍 
- `src/monitor.js`
    - Added `sourceDir` parameter to the spawning of the `chatbot` and `webserver` for the purpose of experimenting with a possible fix for `Error: Target script does not exist: <webserver or chatbot>.js`.<br>(ref. https://stackoverflow.com/a/20430857)